### PR TITLE
fix/ensure_session_id

### DIFF
--- a/import/mycroftcontroller.cpp
+++ b/import/mycroftcontroller.cpp
@@ -266,11 +266,20 @@ void MycroftController::sendRequest(const QString &type, const QVariantMap &data
         qWarning() << "mycroft connection not open!";
         return;
     }
-    QJsonObject root;
 
+    QJsonObject root;
     root[QStringLiteral("type")] = type;
     root[QStringLiteral("data")] = QJsonObject::fromVariantMap(data);
-    root[QStringLiteral("context")] = QJsonObject::fromVariantMap(context);
+
+    // Ensure context has {"session": {"session_id": "default"}}
+    QJsonObject contextJson = QJsonObject::fromVariantMap(context);
+    if (!contextJson.contains(QStringLiteral("session"))) {
+        QJsonObject session;
+        session[QStringLiteral("session_id")] = QStringLiteral("default");
+        contextJson[QStringLiteral("session")] = session;
+    }
+
+    root[QStringLiteral("context")] = contextJson;
 
     QJsonDocument doc(root);
     m_mainWebSocket.sendTextMessage(QString::fromUtf8(doc.toJson()));

--- a/import/mycroftcontroller.h
+++ b/import/mycroftcontroller.h
@@ -88,6 +88,7 @@ Q_SIGNALS:
     void utteranceManagedBySkill(const QString &skill);
     void skillTimeoutReceived(const QString &skillidleid);
 
+
 public Q_SLOTS:
     void start();
     void disconnectSocket();


### PR DESCRIPTION
ensure message.context contains session_id in all messages, this avoids the log spam in other core services when deserializing the message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced request handling with improved context management, ensuring consistent session information for interactions.
  
- **Style**
	- Minor formatting adjustment for improved readability in the MycroftController class.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->