### PR TITLE
Add fullscreen troubleshooting directions

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,4 +139,7 @@ Having trouble or facing issues with Mycroft GUI ? You can use the below guide t
    
    - Run `mycroft-enclosure-client` This will start the client and show Debug() messages on the console.
 
+### Fullscreen Mode for ovos-gui-app 
+On some Linux OSs using Wayland as the Window Manager, the `ovos-qui-app` doesn't natively run in fullscreen mode. One possible solution is to change the `QT_QPA_PLATFORM` variable from `wayland;xcb` to `eglfs` in the systemd unit file located in `/home/<user>/.config/systemd/user`.
+
 ## 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,6 @@ Having trouble or facing issues with Mycroft GUI ? You can use the below guide t
    - Run `mycroft-enclosure-client` This will start the client and show Debug() messages on the console.
 
 ### Fullscreen Mode for ovos-gui-app 
-On some Linux OSs using Wayland as the Window Manager, the `ovos-qui-app` doesn't natively run in fullscreen mode. One possible solution is to change the `QT_QPA_PLATFORM` variable from `wayland;xcb` to `eglfs` in the systemd unit file located in `/home/<user>/.config/systemd/user`.
+On some Linux OSs using Wayland as the Window Manager, the `ovos-gui-app` doesn't natively run in fullscreen mode. One possible solution is to change the `QT_QPA_PLATFORM` variable from something like `wayland;xcb` to `eglfs` in the systemd unit file located in `/home/<user>/.config/systemd/user`.
 
 ## 


### PR DESCRIPTION
I struggled with this on my Pi4 running Raspbian after installing with the ovos-installer in using the virtualenv option. The ovos-gui-app displayed as a "window in window" with 2 sets of window controls. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new section in the README for enabling fullscreen mode on Linux with Wayland for the ovos-gui-app.

- **Documentation**
	- Updated installation instructions and improved the organization of the troubleshooting section.
	- Minor formatting adjustments for clarity throughout the document.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->